### PR TITLE
Map blocks to TextAttributes

### DIFF
--- a/src/mappers.ts
+++ b/src/mappers.ts
@@ -334,7 +334,7 @@ export const mapMessage = (
 
   if (slackMessage.blocks) {
     // @ts-expect-error
-    const data = mapBlocks(slackMessage.blocks)
+    const data = mapBlocks(slackMessage.blocks, customEmojis)
     mappedText = data.text
     textAttributes = data.textAttributes
   } else if (text) {

--- a/src/tests/text-attributes.test.ts
+++ b/src/tests/text-attributes.test.ts
@@ -117,6 +117,7 @@ test('mapBlocks', () => {
       textAttributes: TextAttributes
     }
   }
+  const customEmojis = {}
   const cases: Case[] = [
     {
       blocks: [
@@ -191,7 +192,7 @@ test('mapBlocks', () => {
     },
   ]
   for (const c of cases) {
-    const result = mapBlocks(c.blocks)
+    const result = mapBlocks(c.blocks, customEmojis)
     expect(result).toEqual(c.result)
   }
 })


### PR DESCRIPTION
The existing `mapBlocks` seems to use `blocks` to transform the `text` field, but `blocks` already contains all the information we want. This PR introduces a new `mapBlocks`, and improve the handling of many cases. An example is body text together with attachments text

![image](https://user-images.githubusercontent.com/1082650/131202458-0a7ad3b8-f554-4a38-bf29-34de902a219c.png)

Another example is body text together with link preview

![image](https://user-images.githubusercontent.com/1082650/131202503-be3d07a7-f4a9-49e8-93f7-0ccee5e76264.png)

Notice the favicon doesn't look very good, should be fixed on the frontend I guess.

Handling of custom emojis is moved into text-attributes.ts as well, ~~I'd like to leave it to another PR.~~