### PR TITLE
feat(mappers): map attachments texts and inline images

### DIFF
--- a/src/mappers.ts
+++ b/src/mappers.ts
@@ -372,6 +372,7 @@ export const mapMessage = (
     })
   }
   const action = mapAction(slackMessage)
+
   return {
     _original: JSON.stringify(slackMessage),
     id: slackMessage.ts,
@@ -392,7 +393,7 @@ export const mapMessage = (
 }
 
 export const mapParticipant = ({ profile }: any): Participant => profile && {
-  id: profile.api_app_id || profile.id,
+  id: profile.id || profile.bot_id || profile.api_app_id,
   username: profile.display_name || profile.real_name || profile.name,
   fullName: profile.real_name || profile.display_name,
   imgURL: profile.image_192 || profile.image_72,


### PR DESCRIPTION
- Add support for attachments

I've debugged this with some apps and most of them use this structure so most of them would work.

![image](https://user-images.githubusercontent.com/23640619/131918576-8817d91f-7c91-4008-ab0f-e9a743d2de49.png)

