### PR TITLE
Whenever there is a problem with auth, pass the fetched HTML to sentry

### DIFF
--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -1,3 +1,5 @@
+import os from 'os'
+import path from 'path'
 import { MessageContent, Thread, texts, FetchOptions, OnServerEventCallback, ServerEventType, Participant, ActivityType } from '@textshq/platform-sdk'
 import { WebClient, WebClientOptions } from '@slack/web-api'
 import { promises as fs } from 'fs'
@@ -116,6 +118,12 @@ export default class SlackAPI {
       followRedirect: true,
     })
 
+    await fs.writeFile(path.join(os.homedir(), 'Desktop', 'texts-slack-issue-fetch-html-' + Date.now() + '.json'), JSON.stringify(
+      { url, statusCode, html, cookieJar: this.cookieJar, headers: SlackAPI.htmlHeaders, timestamp: Date.now() },
+      null,
+      2,
+    ))
+
     if (statusCode >= 400) {
       throw Error(`${url} returned status code ${statusCode}`)
     }
@@ -140,6 +148,11 @@ export default class SlackAPI {
 
   private getFirstTeamURL = async () => {
     const res = await texts.fetch('https://my.slack.com/', { cookieJar: this.cookieJar, headers: SlackAPI.htmlHeaders, method: 'HEAD', followRedirect: false })
+    await fs.writeFile(path.join(os.homedir(), 'Desktop', 'texts-slack-issue-get-team-url-' + Date.now() + '.json'), JSON.stringify(
+      { res, cookieJar: this.cookieJar, headers: SlackAPI.htmlHeaders, timestamp: Date.now() },
+      null,
+      2,
+    ))
     const { location } = res.headers
     if (location && location !== 'https://slack.com/') return location
     return this.getFirstTeamURLOld()


### PR DESCRIPTION
We're experiencing a high number of authentication errors. They seem to be related to 2FA but so far I haven't been able to reproduce them. I've tried with multiple workspaces (with different team URLs, 2FA enabled/disabled, SSO enabled/disabled) with no luck.

In order to debug this further we need to see what's the HTML we're getting during auth.

Note we've found two sources of errors:

1. When calling `getConfig` [[example](http://sentry.texts.com/organizations/sentry/discover/texts-app-desktop:2df79e53c3c74b90be11ffa19806526f/?field=title&field=release&field=environment&field=user&field=timestamp&name=SyntaxError%3A+Unterminated+string+in+JSON+at+position+79+%28line+1+column+80%29&project=2&query=issue%3ATEXTS-APP-DESKTOP-6HFW+device_id%3A78d1618a33f1b0b35580715350f6f7c9d85d932335233213bf5f8ec296a8fabd+slack&sort=-timestamp&statsPeriod=14d&yAxis=count%28%29)]
2. When calling `getFirstTeamURLOld` [[example](http://sentry.texts.com/organizations/sentry/discover/texts-app-desktop:0b8fc447e94149b59fb6162e27c705bc/?field=title&field=release&field=environment&field=user&field=timestamp&name=Error%3A+slack+login+error%3A+Error+Could+not+find+team+URL&project=2&query=issue%3ATEXTS-APP-DESKTOP-6285+device_id%3Aef1d847dea31eaafc89c9043755fb08d4e9fd0bdaeaa547f9ba292def60e524e&sort=-timestamp&statsPeriod=14d&yAxis=count%28%29)]