### PR TITLE
Fix regexp for fetching team config when team name contains parenthesis

### DIFF
--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -160,7 +160,7 @@ export default class SlackAPI {
 
   private getConfig = async () => {
     const html = await this.fetchHTML('https://app.slack.com/auth?app=client')
-    const [, json] = html.match(/JSON.stringify\((.+?)\)/) || []
+    const [, json] = html.match(/JSON\.stringify\((\{.*?\})\)/) || []
     const config = JSON.parse(json)
     return config
   }


### PR DESCRIPTION
After we fixed some of the auth problems related to 2FA in #40, we were still seeing errors related to authentication.
With the help of one the affected users, I've found that one of the regexps involved in parsing the auth responses was not working properly if the slack workspace name contained parenthesis:

### Before
```regexp
/JSON.stringify\((.+?)\)/
```

<img width="976" alt="image" src="https://github.com/TextsHQ/platform-slack/assets/855995/1dfacd1c-0d0b-44db-9965-12f0f5a38308">


### After
```regexp
/JSON\.stringify\((\{.*?\})\)/
```

<img width="985" alt="image" src="https://github.com/TextsHQ/platform-slack/assets/855995/bcbeb77f-cd17-4488-a510-16fc4551dc4b">

--- 
This was causing `JSON.parse` to crash, as the JSON was incomplete.