### PR TITLE
add indentation to nested lists

### DIFF
--- a/src/text-attributes.ts
+++ b/src/text-attributes.ts
@@ -346,7 +346,7 @@ function mapBlock(block: Block, customEmojis: Record<string, string>, fallbackTe
     }
     case 'rich_text_list': {
       let i = 1
-      const indentation = Array.from({ length: block.indent || 0 }).reduce(prev => `${prev} `, '')
+      const indentation = Array.from({ length: block.indent || 0 }).reduce(prev => `${prev}  `, '')
 
       for (const element of block.elements) {
         const listStyle = block.style === 'ordered' ? `${indentation}${i}. ` : `${indentation}• `


### PR DESCRIPTION
## Context
we were not mapping nested lists (they're being rendered as flat lists) so this PR adds indentation to elements.

## Screenshots
### Before
![image](https://github.com/TextsHQ/platform-slack/assets/23640619/778ba9a8-1ee4-411d-ba47-3b050ad4e5e4)

### After
<img width="325" alt="image" src="https://github.com/TextsHQ/platform-slack/assets/23640619/9be8224a-626b-4f3c-8844-1165a7faa93d">

