### PR TITLE
Fix blank threads by querying at least 1 messages

### DIFF
--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -333,14 +333,6 @@ export default class SlackAPI {
             }
           })
 
-          this.onEvent([{
-            type: ServerEventType.STATE_SYNC,
-            mutationType: 'upsert',
-            objectIDs: {},
-            objectName: 'thread',
-            entries: mappedThreads,
-          }])
-
           allThreads.push(...mappedThreads)
         }
 


### PR DESCRIPTION
This PR fixes a bug causing thread messages to disappear from time to time.

This fix queries the latest message and returns it, so that threads never return an empty message array (unless if they just don't have any messages inside)