### PR TITLE
Fix bot participant mapping

### DIFF
--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -512,7 +512,14 @@ export default class SlackAPI {
     const foundKey = keys.find(key => this.workspaceUsers[key]?.profile?.api_app_id === bot.bot.app_id)
     const user = this.workspaceUsers[foundKey] || {}
 
-    const participant = { profile: { ...bot.bot, ...(user?.profile || {}), id: bot.bot.app_id } }
+    const participant = {
+      profile: {
+        ...(user?.profile || {}),
+        ...bot.bot,
+        id: bot.bot.app_id,
+      }
+    }
+
     this.workspaceUsers[botId] = participant
     return participant
   }

--- a/src/mappers.ts
+++ b/src/mappers.ts
@@ -340,7 +340,7 @@ export const mapParticipant = ({ profile }: any): Participant => {
 export const mapCurrentUser = ({ user, team, auth }: any): CurrentUser => ({
   id: auth.enterprise_id ? `${auth.enterprise_id}-${team.id}-${auth.user_id}` : auth.user_id,
   fullName: user.real_name,
-  displayText: `${team?.name + ' - '}${user.display_name || user.real_name}`,
+  displayText: `${team?.name} - ${user.display_name || user.real_name}`,
   imgURL: user.image_192,
 })
 

--- a/src/mappers.ts
+++ b/src/mappers.ts
@@ -309,12 +309,32 @@ export const mapMessage = (
   }
 }
 
-export const mapParticipant = ({ profile }: any): Participant => profile && {
-  id: profile.user_id || profile.id || profile.bot_id || profile.api_app_id,
-  username: profile.display_name || profile.real_name || profile.name,
-  fullName: profile.real_name || profile.display_name,
-  imgURL: profile.image_192 || profile.image_72,
-  email: profile.email,
+export const mapAppOrBot = ({ profile }: {
+  profile: {
+    name: string
+    display_name: string
+    real_name: string
+    id: string
+    icons: Record<string, string>
+  }
+}): Participant => profile && {
+  id: profile.id,
+  username: profile.name || profile.display_name,
+  fullName: profile.name || profile.display_name,
+  imgURL: profile.icons?.image_72 || profile.icons?.image_48 || profile.icons?.image_32,
+}
+
+export const mapParticipant = ({ profile }: any): Participant => {
+  if (!profile) return
+  if (profile.app_id) return mapAppOrBot({ profile })
+
+  return {
+    id: profile.user_id || profile.id || profile.bot_id || profile.api_app_id,
+    username: profile.display_name || profile.real_name || profile.name,
+    fullName: profile.real_name || profile.display_name,
+    imgURL: profile.image_192 || profile.image_72,
+    email: profile.email,
+  }
 }
 
 export const mapCurrentUser = ({ user, team, auth }: any): CurrentUser => ({


### PR DESCRIPTION
## Context
We were showing the name of the user and more data that is mapped as "fallback"; so this PR fixes that checking the field `app_id` is present and if so it will map the bot correctly.

<img width="473" alt="image" src="https://github.com/TextsHQ/platform-slack/assets/23640619/17b0b814-b9c8-434f-bca0-c24aee5eca3f">
